### PR TITLE
Add visitor support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/analytics",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/analytics",
-      "version": "0.2.0-beta.2",
+      "version": "0.2.0-beta.4",
       "dependencies": {
         "cross-fetch": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/analytics",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.4",
   "description": "An analytics library for Yext Answers",
   "author": "slapshot@yext.com",
   "main": "./lib/commonjs/index.js",

--- a/src/models/AnalyticsConfig.ts
+++ b/src/models/AnalyticsConfig.ts
@@ -1,3 +1,5 @@
+import { Visitor } from './Visitor';
+
 /**
  * The main configuration options for the {@link AnalyticsReporter}.
  *
@@ -10,6 +12,8 @@ export interface AnalyticsConfig {
   experienceVersion: 'PRODUCTION' | 'STAGING' | string,
   /** The businessId of the answers experience. */
   businessId: number,
-  /** The domain to send the requests to */
+  /** The domain to send the requests to. */
   domain?: string,
+  /** {@inheritDoc Visitor} */
+  visitor?: Visitor
 }

--- a/src/models/Visitor.ts
+++ b/src/models/Visitor.ts
@@ -1,0 +1,13 @@
+/**
+ * Information used to associate analytics with a particular user.
+ */
+export interface Visitor {
+  /** The ID associated with the user. */
+  id: string,
+  /**
+   * The type of visitor.
+   *
+   * @example 'YEXT_USER' for Yext Auth
+   */
+  method?: string
+}

--- a/src/models/events/VerticalViewAllEvent.ts
+++ b/src/models/events/VerticalViewAllEvent.ts
@@ -5,7 +5,7 @@ import { EnumOrLiteral } from '../utils';
 export interface VerticalViewAllEvent {
   type: EnumOrLiteral<AnalyticsEventType.VerticalViewAll>,
   /** {@inherticDoc CtaData.queryId} */
-  queryId?: string,
+  queryId: string,
   /** The vertical key of the vertical for which the event was fired. */
   verticalKey: string
 }

--- a/src/services/AnalyticsService.ts
+++ b/src/services/AnalyticsService.ts
@@ -1,10 +1,12 @@
 import { BeaconPayload } from '../models';
 import { AnalyticsEvent } from '../models/events/AnalyticsEvent';
 import { AnalyticsResponse } from '../models/AnalyticsResponse';
+import { Visitor } from '../models/Visitor';
 
 /**
  * A service for Analytics
  */
 export interface AnalyticsService {
   report(event: AnalyticsEvent, additionalRequestAttributes?: BeaconPayload): AnalyticsResponse;
+  setVisitor(visitor: Visitor | undefined): void;
 }

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -22,7 +22,7 @@
     },
     "..": {
       "name": "@yext/analytics",
-      "version": "0.2.0-beta.2",
+      "version": "0.2.0-beta.4",
       "dependencies": {
         "cross-fetch": "^3.0.0"
       },

--- a/tests/infra/AnalyticsReporter.ts
+++ b/tests/infra/AnalyticsReporter.ts
@@ -74,3 +74,28 @@ it('A status of "error" is returned for unsuccessful beacons', () => {
   const metadata = analyticsReporter.report({ type: 'SCROLL_TO_BOTTOM_OF_PAGE', queryId: '1' });
   expect(metadata).toEqual({ status: 'error', message: expect.anything() });
 });
+
+it('Visitor is set and passed properly', () => {
+  const visitorParam = { visitor: { id: '123'} };
+  const analyticsReporter = new AnalyticsReporter({...config, ...visitorParam}, mockHttpRequesterService);
+  analyticsReporter.report({ type: 'SCROLL_TO_BOTTOM_OF_PAGE', queryId: '1' });
+  const data = {
+    businessId: 123,
+    eventType: 'SCROLL_TO_BOTTOM_OF_PAGE',
+    experienceKey: 'yext',
+    experienceVersion: 'PRODUCTION',
+    queryId: '1'
+  };
+  const expectedDataWithVisitor = {
+    data: {
+      ...data,
+      ...visitorParam
+    }
+  };
+  expect(mockHttpRequesterService.beacon).toHaveBeenLastCalledWith(expect.anything(),
+    expectedDataWithVisitor);
+
+  analyticsReporter.setVisitor();
+  analyticsReporter.report({ type: 'SCROLL_TO_BOTTOM_OF_PAGE', queryId: '1' });
+  expect(mockHttpRequesterService.beacon).toHaveBeenLastCalledWith(expect.anything(), { data });
+});


### PR DESCRIPTION
Allow a visitor to be specified in the config or changed with a `setVisitor` method. The visitor information, when present, is passed with all analytics events.

J=SLAP-1890
TEST=auto, manual

Add a jest test and check that test-site sets and sends the visitor correctly with analytics events.