### PR TITLE
Add search duration event types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/analytics",
-  "version": "0.2.0-beta.4",
+  "version": "0.2.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/analytics",
-      "version": "0.2.0-beta.4",
+      "version": "0.2.0-beta.5",
       "dependencies": {
         "cross-fetch": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/analytics",
-  "version": "0.2.0-beta.4",
+  "version": "0.2.0-beta.5",
   "description": "An analytics library for Yext Answers",
   "author": "slapshot@yext.com",
   "main": "./lib/commonjs/index.js",

--- a/src/models/AnalyticsEventType.ts
+++ b/src/models/AnalyticsEventType.ts
@@ -29,4 +29,9 @@ export enum AnalyticsEventType {
   Email = 'EMAIL',
   BookAppointment = 'BOOK_APPOINTMENT',
   Rsvp = 'RSVP',
+
+  // Search duration event types
+  ResultsHidden = 'RESULTS_HIDDEN',
+  ResultsUnhidden = 'RESULTS_UNHIDDEN',
+  FollowUpQuery = 'FOLLOW_UP_QUERY'
 }

--- a/src/models/events/AccordionToggleEvent.ts
+++ b/src/models/events/AccordionToggleEvent.ts
@@ -5,12 +5,12 @@ import { Searcher } from '../Searcher';
 /** Event for expanding or collapsing an accordion row. */
 export interface AccordionToggleEvent {
   type: EnumOrLiteral<AnalyticsEventType.RowExpand | AnalyticsEventType.RowCollapse>,
-  /** {@inherticDoc CtaData.queryId} */
+  /** {@inherticDoc CtaEvent.queryId} */
   queryId: string,
-  /** {@inheritDoc CtaData.verticalKey} */
+  /** {@inheritDoc CtaEvent.verticalKey} */
   verticalKey: string,
-  /** {@inheritDoc CtaData.entityId} */
+  /** {@inheritDoc CtaEvent.entityId} */
   entityId: string,
-  /** {@inheritDoc CtaData.searcher} */
+  /** {@inheritDoc CtaEvent.searcher} */
   searcher?: Searcher
 }

--- a/src/models/events/AnalyticsEvent.ts
+++ b/src/models/events/AnalyticsEvent.ts
@@ -9,6 +9,7 @@ import { SearchClearEvent } from './SearchClearEvent';
 import { PaginationEvent } from './PaginationEvent';
 import { AutocompleteEvent } from './AutocompleteEvent';
 import { VerticalViewAllEvent } from './VerticalViewAllEvent';
+import { SearchDurationEvent } from './SearchDurationEvent';
 
 /**
  * An analytics event
@@ -20,6 +21,7 @@ export type AnalyticsEvent =
   ScrollEvent |
   SearchBarImpressionEvent |
   SearchClearEvent |
+  SearchDurationEvent |
   ThumbsFeedbackEvent |
   VerticalViewAllEvent |
   VoiceSearchEvent |

--- a/src/models/events/AutocompleteEvent.ts
+++ b/src/models/events/AutocompleteEvent.ts
@@ -6,6 +6,6 @@ export interface AutocompleteEvent {
   type: EnumOrLiteral<AnalyticsEventType.AutocompleteSelection>,
   /** Selected search text from an autocomplete suggestion. */
   suggestedSearchText: string,
-  /** {@inherticDoc CtaData.queryId} */
+  /** {@inherticDoc CtaEvent.queryId} */
   queryId?: string
 }

--- a/src/models/events/CtaEvent.ts
+++ b/src/models/events/CtaEvent.ts
@@ -16,7 +16,8 @@ export interface CtaEvent {
     AnalyticsEventType.ViewWebsite |
     AnalyticsEventType.Email |
     AnalyticsEventType.BookAppointment |
-    AnalyticsEventType.Rsvp>,
+    AnalyticsEventType.Rsvp
+  >,
   /**
    * The vertical key for the vertical on which the event was fired. Or, if
    * it is a universal search, the vertical key for the section in the universal

--- a/src/models/events/PaginationEvent.ts
+++ b/src/models/events/PaginationEvent.ts
@@ -4,7 +4,7 @@ import { EnumOrLiteral } from '../utils';
 /** Event for pagination interaction. */
 export interface PaginationEvent {
   type: EnumOrLiteral<AnalyticsEventType.Paginate>,
-  /** {@inheritDoc CtaData.verticalKey} */
+  /** {@inheritDoc CtaEvent.verticalKey} */
   verticalKey: string,
   /** The ID of the query correspond to this pagination sequence. */
   queryId: string,

--- a/src/models/events/ScrollEvent.ts
+++ b/src/models/events/ScrollEvent.ts
@@ -3,6 +3,6 @@ import { EnumOrLiteral } from '../utils';
 
 export interface ScrollEvent {
   type: EnumOrLiteral<AnalyticsEventType.ScrollToBottomOfPage>,
-  /** {@inherticDoc CtaData.queryId} */
+  /** {@inherticDoc CtaEvent.queryId} */
   queryId: string
 }

--- a/src/models/events/SearchBarImpressionEvent.ts
+++ b/src/models/events/SearchBarImpressionEvent.ts
@@ -7,8 +7,8 @@ export interface SearchBarImpressionEvent {
   type: EnumOrLiteral<AnalyticsEventType.SearchBarImpression>,
   /** Whether or not the impression came from a standalone search bar */
   standAlone: boolean,
-  /** {@inheritDoc CtaData.verticalKey} */
+  /** {@inheritDoc CtaEvent.verticalKey} */
   verticalKey?: string,
-  /** {@inheritDoc CtaData.searcher} */
+  /** {@inheritDoc CtaEvent.searcher} */
   searcher?: Searcher
 }

--- a/src/models/events/SearchClearEvent.ts
+++ b/src/models/events/SearchClearEvent.ts
@@ -4,7 +4,7 @@ import { EnumOrLiteral } from '../utils';
 /** Event for clicking on the button to clear the search input. */
 export interface SearchClearEvent {
   type: EnumOrLiteral<AnalyticsEventType.SearchClearButton>,
-  /** {@inherticDoc CtaData.queryId} */
+  /** {@inherticDoc CtaEvent.queryId} */
   queryId: string,
   /** The vertical key of the vertical if the event was not fired on a universal page. */
   verticalKey?: string

--- a/src/models/events/SearchDurationEvent.ts
+++ b/src/models/events/SearchDurationEvent.ts
@@ -2,13 +2,15 @@ import { AnalyticsEventType } from '../AnalyticsEventType';
 import { Searcher } from '../Searcher';
 import { EnumOrLiteral } from '../utils';
 
-/** Event for submitting a question. */
-export interface QuestionSubmissionEvent {
-  type: EnumOrLiteral<AnalyticsEventType.QuestionFocus | AnalyticsEventType.QuestionSubmit>,
+/** Event used to calculate the duration of a search. */
+export interface SearchDurationEvent {
+  type: EnumOrLiteral<
+    AnalyticsEventType.ResultsHidden |
+    AnalyticsEventType.ResultsUnhidden |
+    AnalyticsEventType.FollowUpQuery
+  >,
   /** {@inherticDoc CtaEvent.queryId} */
   queryId: string,
-  /** {@inheritDoc CtaEvent.verticalKey} */
-  verticalKey: string,
   /** {@inheritDoc CtaEvent.searcher} */
   searcher: Searcher
 }

--- a/src/models/events/ThumbsFeedbackEvent.ts
+++ b/src/models/events/ThumbsFeedbackEvent.ts
@@ -5,14 +5,14 @@ import { EnumOrLiteral } from '../utils';
 /** Event for submitting thumbs up/down feedback (ThumbsUp and ThumbsDown). */
 export interface ThumbsFeedbackEvent {
   type: EnumOrLiteral<AnalyticsEventType.ThumbsUp | AnalyticsEventType.ThumbsDown>,
-  /** {@inherticDoc CtaData.queryId} */
+  /** {@inherticDoc CtaEvent.queryId} */
   queryId: string,
-  /** {@inheritDoc CtaData.directAnswer} */
+  /** {@inheritDoc CtaEvent.directAnswer} */
   directAnswer?: boolean,
-  /** {@inheritDoc CtaData.verticalKey} */
+  /** {@inheritDoc CtaEvent.verticalKey} */
   verticalKey?: string,
-  /** {@inheritDoc CtaData.entityId} */
+  /** {@inheritDoc CtaEvent.entityId} */
   entityId?: string,
-  /** {@inheritDoc CtaData.searcher} */
+  /** {@inheritDoc CtaEvent.searcher} */
   searcher?: Searcher
 }

--- a/src/models/events/VerticalViewAllEvent.ts
+++ b/src/models/events/VerticalViewAllEvent.ts
@@ -4,7 +4,7 @@ import { EnumOrLiteral } from '../utils';
 /** Event for clicking on a vertical's View All button on a universal page. */
 export interface VerticalViewAllEvent {
   type: EnumOrLiteral<AnalyticsEventType.VerticalViewAll>,
-  /** {@inherticDoc CtaData.queryId} */
+  /** {@inherticDoc CtaEvent.queryId} */
   queryId: string,
   /** The vertical key of the vertical for which the event was fired. */
   verticalKey: string

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -22,7 +22,7 @@
     },
     "..": {
       "name": "@yext/analytics",
-      "version": "0.2.0-beta.4",
+      "version": "0.2.0-beta.5",
       "dependencies": {
         "cross-fetch": "^3.0.0"
       },

--- a/test-site/src/index.ts
+++ b/test-site/src/index.ts
@@ -8,7 +8,7 @@ const analytics = provideAnalytics({
 
 export function fireAnalyticsEvent() {
   analytics.report({
-    type: "CTA_CLICK",
+    type: 'CTA_CLICK',
     entityId: '1',
     verticalKey: 'people',
     searcher: 'VERTICAL',


### PR DESCRIPTION
Add a `SearchDurationEvent` and event types for RESULTS_HIDDEN, RESULTS_UNHIDDEN, and FOLLOW_UP_QUERY. Update `inheritDoc`s to point to the correct interface. 

J=SLAP-1913
TEST=manual

Check that each of the 3 new event types fire correctly from the test-site with 200 status.