### PR TITLE
Add tab navigation events

### DIFF
--- a/src/models/AnalyticsEventType.ts
+++ b/src/models/AnalyticsEventType.ts
@@ -2,6 +2,8 @@
  * Represents the possible analytics event types
  */
 export enum AnalyticsEventType {
+  AllTabNavigation = 'ALL_TAB_NAVIGATION',
+  VerticalTabNavigation = 'VERTICAL_TAB_NAVIGATION',
   ScrollToBottomOfPage = 'SCROLL_TO_BOTTOM_OF_PAGE',
   QuestionFocus = 'QUESTION_FOCUS',
   QuestionSubmit = 'QUESTION_SUBMIT',

--- a/src/models/events/AllTabNavigationEvent.ts
+++ b/src/models/events/AllTabNavigationEvent.ts
@@ -1,0 +1,9 @@
+import { AnalyticsEventType } from '../AnalyticsEventType';
+import { EnumOrLiteral } from '../utils';
+
+/** Event for navigating to the 'all' tab (a universal page). */
+export interface AllTabNavigationEvent {
+  type: EnumOrLiteral<AnalyticsEventType.AllTabNavigation>,
+  /** {@inherticDoc CtaEvent.queryId} */
+  queryId?: string
+}

--- a/src/models/events/AnalyticsEvent.ts
+++ b/src/models/events/AnalyticsEvent.ts
@@ -10,6 +10,8 @@ import { PaginationEvent } from './PaginationEvent';
 import { AutocompleteEvent } from './AutocompleteEvent';
 import { VerticalViewAllEvent } from './VerticalViewAllEvent';
 import { SearchDurationEvent } from './SearchDurationEvent';
+import { AllTabNavigationEvent } from './AllTabNavigationEvent';
+import { VerticalTabNavigationEvent } from './VerticalTabNavigationEvent';
 
 /**
  * An analytics event
@@ -26,4 +28,6 @@ export type AnalyticsEvent =
   VerticalViewAllEvent |
   VoiceSearchEvent |
   PaginationEvent |
-  AutocompleteEvent;
+  AutocompleteEvent |
+  AllTabNavigationEvent |
+  VerticalTabNavigationEvent;

--- a/src/models/events/VerticalTabNavigationEvent.ts
+++ b/src/models/events/VerticalTabNavigationEvent.ts
@@ -1,0 +1,11 @@
+import { AnalyticsEventType } from '../AnalyticsEventType';
+import { EnumOrLiteral } from '../utils';
+
+/** Event for navigating to a vertical tab or page. */
+export interface VerticalTabNavigationEvent {
+  type: EnumOrLiteral<AnalyticsEventType.VerticalTabNavigation>,
+  /** {@inheritDoc CtaEvent.verticalKey} */
+  verticalKey: string,
+  /** {@inherticDoc CtaEvent.queryId} */
+  queryId?: string
+}


### PR DESCRIPTION
Add AllTabNavigation and VerticalTabNavigation events

These events should be fired when navigating to universal or vertical pages

SLAP-1945
TEST=manual

Use the test site to fire the events. Confirm the API returns an HTTP 200 for the events. Test events with and without queryId included in the events.