### PR TITLE
update queryParam from id to ids to match pages pixel documentation

### DIFF
--- a/src/infra/PagesAnalyticsReporter.ts
+++ b/src/infra/PagesAnalyticsReporter.ts
@@ -21,7 +21,7 @@ enum urlParamNames {
   Referrer = 'pagesReferrer',
   EventType = 'eventType',
   PageSetId = 'pageSetId',
-  EntityInternalId = 'id',
+  EntityInternalId = 'ids',
   DirectoryId = 'directoryId',
   SearchId = 'searchId',
   StaticPageId = 'staticPageId',

--- a/tests/infra/PagesAnalyticsReporter.ts
+++ b/tests/infra/PagesAnalyticsReporter.ts
@@ -67,7 +67,7 @@ it('should track entity pages', () => {
   expectedUrl.searchParams.set('eventType', 'pageview');
   expectedUrl.searchParams.set('pageType', 'entity');
   expectedUrl.searchParams.set('pageSetId', 'My Page Set');
-  expectedUrl.searchParams.set('id', '1');
+  expectedUrl.searchParams.set('ids', '1');
   expectedUrl.searchParams.set('v', '1001');
   expectedUrl.searchParams.set('pageurl', '/foo/bar');
   expectedUrl.searchParams.set('pagesReferrer','https://www.google.com');
@@ -114,7 +114,7 @@ it('should track directory pages', () => {
   expectedUrl.searchParams.set('eventType', 'pageview');
   expectedUrl.searchParams.set('pageType', 'directory');
   expectedUrl.searchParams.set('directoryId', 'My Directory Page Set');
-  expectedUrl.searchParams.set('id', '1');
+  expectedUrl.searchParams.set('ids', '1');
   expectedUrl.searchParams.set('v', '1001');
   expectedUrl.searchParams.set('pageurl', '/foo/bar');
   expectedUrl.searchParams.set('pagesReferrer','https://www.google.com');


### PR DESCRIPTION
updating the id query param to ids to match the documentation [here](https://www.yext.com/docmd/docs/src/com/yext/analytics/events/pagesevents.html#request-parameters) and to fix entity_id not associating properly with events bug 