### PR TITLE
replace ulid package with ulidx

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -30,6 +30,36 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
+ - layerr@2.0.0
+
+This package contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2020 Perry Mitchell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----------
+
+The following NPM package may be included in this product:
+
  - node-fetch@2.6.7
 
 This package contains the following license and notice below:
@@ -70,13 +100,13 @@ This package contains the following license and notice below:
 
 The following NPM package may be included in this product:
 
- - ulid@2.3.0
+ - ulidx@2.0.0
 
 This package contains the following license and notice below:
 
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2017 Alizain Feerasta
+Copyright (c) 2021 Perry Mitchell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@yext/analytics",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/analytics",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5",
-        "ulid": "^2.3.0"
+        "ulidx": "^2.0.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.14.7",
@@ -7474,6 +7474,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/layerr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/layerr/-/layerr-2.0.0.tgz",
+      "integrity": "sha512-d17+qA3CAekh29Z67nLQaqCXJSvoo9zKBvZAziYdDwTOeA1XdOoTuLtNOLg+TW5Tse+D9bw8VHsTQo5vU7G/kA=="
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -9308,12 +9313,15 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/ulid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
-      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==",
-      "bin": {
-        "ulid": "bin/cli.js"
+    "node_modules/ulidx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ulidx/-/ulidx-2.0.0.tgz",
+      "integrity": "sha512-cz6HnYL8aQeR1l7qgo4qK88kLhnVQn1qLjALMoa4rtmj6/jw3yS2KUxu3r+d8GSKkeK9ctw+n8VmCygqfDtckA==",
+      "dependencies": {
+        "layerr": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -15235,6 +15243,11 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "layerr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/layerr/-/layerr-2.0.0.tgz",
+      "integrity": "sha512-d17+qA3CAekh29Z67nLQaqCXJSvoo9zKBvZAziYdDwTOeA1XdOoTuLtNOLg+TW5Tse+D9bw8VHsTQo5vU7G/kA=="
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -16647,10 +16660,13 @@
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
-    "ulid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
-      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw=="
+    "ulidx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ulidx/-/ulidx-2.0.0.tgz",
+      "integrity": "sha512-cz6HnYL8aQeR1l7qgo4qK88kLhnVQn1qLjALMoa4rtmj6/jw3yS2KUxu3r+d8GSKkeK9ctw+n8VmCygqfDtckA==",
+      "requires": {
+        "layerr": "^2.0.0"
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/analytics",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "An analytics library for Yext",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",
@@ -73,6 +73,6 @@
   },
   "dependencies": {
     "cross-fetch": "^3.1.5",
-    "ulid": "^2.3.0"
+    "ulidx": "^2.0.0"
   }
 }

--- a/src/utils/getOrSetupSessionId.ts
+++ b/src/utils/getOrSetupSessionId.ts
@@ -1,4 +1,4 @@
-import { ulid } from 'ulid';
+import { ulid } from 'ulidx';
 
 export const SESSION_ID_KEY = 'yext_analytics_session_id';
 

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,11 +23,11 @@
     },
     "..": {
       "name": "@yext/analytics",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5",
-        "ulid": "^2.3.0"
+        "ulidx": "^2.0.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.14.7",
@@ -6123,7 +6123,7 @@
         "jest-fetch-mock": "^3.0.3",
         "prettier": "^2.8.8",
         "typescript": "^4.1.5",
-        "ulid": "^2.3.0"
+        "ulidx": "^2.0.0"
       }
     },
     "@zeit/schemas": {

--- a/test-site/src/node/index.js
+++ b/test-site/src/node/index.js
@@ -1,11 +1,38 @@
-const { provideAnalytics, AnalyticsEvent } = require('@yext/analytics');
+const { provideAnalytics, provideChatAnalytics } = require('@yext/analytics');
+const dotenv = require('dotenv')
+dotenv.config();
 
-const analytics = provideAnalytics({
-  experienceKey: 'rosetest',
-  experienceVersion: 'PRODUCTION',
-  businessId: 123,
-});
+async function searchAnalyticsTest() {
+  const analytics = provideAnalytics({
+    experienceKey: 'rosetest',
+    experienceVersion: 'PRODUCTION',
+    businessId: 123,
+  });
+  
+  const response = await analytics.report({
+    type: 'CTA_CLICK',
+    entityId: '1',
+    verticalKey: 'people',
+    searcher: 'VERTICAL',
+    queryId: '95751527-9db6-4859-8278-60d1c060b6c0'
+  });
+  console.log("Search response", response);
+}
 
-const event = new AnalyticsEvent('CTA_CLICK');
-const response = analytics.report(event);
-console.log(response);
+
+async function chatAnalyticsTest() {
+  const chatAnalytics = provideChatAnalytics({
+    apiKey: process.env.CHAT_API_KEY,
+    sessionTrackingEnabled: true,
+  });
+  const chatResponse = await chatAnalytics.report({
+    action: "CHAT_LINK_CLICK",
+    chat: {
+      botId: "analytics-test-bot"
+    }
+  });
+  console.log("Chat response", chatResponse);
+}
+
+searchAnalyticsTest()
+chatAnalyticsTest()

--- a/tests/infra/ChatAnalyticsReporter.ts
+++ b/tests/infra/ChatAnalyticsReporter.ts
@@ -1,7 +1,7 @@
 import { ChatAnalyticsReporter } from '../../src/infra/ChatAnalyticsReporter';
 import { ChatAnalyticsConfig, ChatEventPayLoad, EventAPIResponse } from '../../src/models';
 import { mockErrorHttpRequesterService, mockHttpRequesterService } from '../../src/services/__mocks__/MockHttpRequesterService';
-import * as ulidLib from 'ulid';
+import ulidxLib from 'ulidx';
 
 const prodConfig: ChatAnalyticsConfig = {
   apiKey: 'mock-api-key',
@@ -22,7 +22,7 @@ const payload: ChatEventPayLoad = {
 };
 
 beforeEach(() => {
-  jest.spyOn(ulidLib, 'ulid').mockReturnValue('mocked-ulid-value');
+  jest.spyOn(ulidxLib, 'ulid').mockReturnValue('mocked-ulid-value');
 });
 
 const mockedResponse: EventAPIResponse = { id: '12345' };
@@ -101,7 +101,7 @@ it('converts timestamps to ISO strings', async () => {
 
 describe('sessionId handling', () => {
   beforeEach(() => {
-    jest.spyOn(ulidLib, 'ulid').mockReturnValue('mocked-ulid-value');
+    jest.spyOn(ulidxLib, 'ulid').mockReturnValue('mocked-ulid-value');
   });
 
   it('defaults sessionTrackingEnabled to true for US', async () => {

--- a/tests/utils/getOrSetupSessionId.ts
+++ b/tests/utils/getOrSetupSessionId.ts
@@ -1,8 +1,8 @@
 import { SESSION_ID_KEY, getOrSetupSessionId } from '../../src/utils/getOrSetupSessionId';
-import * as ulidLib from 'ulid';
+import ulidxLib from 'ulidx';
 
 it('returns generated ulid as expected', () => {
-  const mockedUlidFn = jest.spyOn(ulidLib, 'ulid').mockReturnValue('mocked-ulid-value');
+  const mockedUlidFn = jest.spyOn(ulidxLib, 'ulid').mockReturnValue('mocked-ulid-value');
   const id = getOrSetupSessionId();
 
   expect(mockedUlidFn).toBeCalledTimes(1);
@@ -16,7 +16,7 @@ it('fetches existing ulid from session storage', () => {
     }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any));
-  const mockedUlidFn = jest.spyOn(ulidLib, 'ulid').mockReturnValue('mocked-ulid-value');
+  const mockedUlidFn = jest.spyOn(ulidxLib, 'ulid').mockReturnValue('mocked-ulid-value');
   const id = getOrSetupSessionId();
 
   expect(mockedUlidFn).not.toBeCalled();
@@ -25,7 +25,7 @@ it('fetches existing ulid from session storage', () => {
 });
 
 it('returns without error when window is undefined', () => {
-  const mockedUlidFn = jest.spyOn(ulidLib, 'ulid').mockReturnValue('mocked-ulid-value');
+  const mockedUlidFn = jest.spyOn(ulidxLib, 'ulid').mockReturnValue('mocked-ulid-value');
   // Simulate a node environment where the window is undefined
   const windowSpy = jest.spyOn(window, 'window', 'get');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,7 +38,7 @@ it('returns without error when window is undefined', () => {
 });
 
 it('logs a warning in console when sessionStorage is not accessible', () => {
-  const mockedUlidFn = jest.spyOn(ulidLib, 'ulid').mockReturnValue('mocked-ulid-value');
+  const mockedUlidFn = jest.spyOn(ulidxLib, 'ulid').mockReturnValue('mocked-ulid-value');
   const windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
     sessionStorage: undefined
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
ulid package have issue with node crypto import, result in error: `Error: secure crypto unusable, insecure Math.random not allowed`. See discussion thread for more details: https://yext.slack.com/archives/C02UVSE7P6W/p1689280215531739

this PR updates ulid to ulidx


TEST=manual&auto

see that jest tests passed
see that it still generates sessionId in test-site browser and node (also tested with the repo linked in this discussion: https://yext.slack.com/archives/C02UVSE7P6W/p1689280215531739)

https://github.com/yext/analytics/assets/36055303/f1935795-1a5c-440f-95c5-865943d2cb51
