### PR TITLE
Remove www from yextevents URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/analytics",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "An analytics library for Yext",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",

--- a/src/utils/endpointProviders.ts
+++ b/src/utils/endpointProviders.ts
@@ -4,11 +4,11 @@ type DomainMap = Record<Region, Record<Environment, string | undefined>>;
 
 const EVENT_DOMAINS: DomainMap = {
   US: {
-    PRODUCTION: 'https://www.us.yextevents.com',
-    SANDBOX: 'https://www.sbx.us.yextevents.com',
+    PRODUCTION: 'https://us.yextevents.com',
+    SANDBOX: 'https://sbx.us.yextevents.com',
   },
   EU: {
-    PRODUCTION: 'https://www.eu.yextevents.com',
+    PRODUCTION: 'https://eu.yextevents.com',
     SANDBOX: undefined
   }
 };

--- a/tests/infra/ChatAnalyticsReporter.ts
+++ b/tests/infra/ChatAnalyticsReporter.ts
@@ -30,7 +30,7 @@ const mockedResponse: EventAPIResponse = { id: '12345' };
 it('should send events to the prod domain when configured', async () => {
   const mockService = mockHttpRequesterService(mockedResponse);
   const reporter = new ChatAnalyticsReporter(prodConfig, mockService);
-  const expectedUrl ='https://www.us.yextevents.com/accounts/me/events';
+  const expectedUrl ='https://us.yextevents.com/accounts/me/events';
   const response = await reporter.report(payload);
   expect(response).toEqual(mockedResponse);
   expect(mockService.post).toBeCalledWith(

--- a/tests/infra/PagesAnalyticsReporter.ts
+++ b/tests/infra/PagesAnalyticsReporter.ts
@@ -22,7 +22,7 @@ it('The static page page view URL is constructed correctly', () => {
   }, httpRequesterService);
 
   reporter.pageView();
-  const expectedUrl = new URL('https://www.us.yextevents.com/store_pagespixel');
+  const expectedUrl = new URL('https://us.yextevents.com/store_pagespixel');
 
   expectedUrl.searchParams.set('businessids', '0');
   expectedUrl.searchParams.set('product', 'sites');
@@ -59,7 +59,7 @@ it('Should handle http errors properly', () => {
 
 it('should track entity pages', () => {
   const httpRequesterService = mockHttpRequesterService();
-  const expectedUrl = new URL('https://www.us.yextevents.com/store_pagespixel');
+  const expectedUrl = new URL('https://us.yextevents.com/store_pagespixel');
   expectedUrl.searchParams.set('businessids', '0');
   expectedUrl.searchParams.set('product', 'sites');
   expectedUrl.searchParams.set('siteId', '0');
@@ -105,7 +105,7 @@ it('should track directory pages', () => {
   }, httpRequesterService);
   reporter.pageView();
 
-  const expectedUrl = new URL('https://www.us.yextevents.com/store_pagespixel');
+  const expectedUrl = new URL('https://us.yextevents.com/store_pagespixel');
 
   expectedUrl.searchParams.set('businessids', '0');
   expectedUrl.searchParams.set('product', 'sites');
@@ -137,7 +137,7 @@ it('should track locator pages', () => {
   }, httpRequesterService);
   reporter.pageView();
 
-  const expectedUrl = new URL('https://www.us.yextevents.com/store_pagespixel');
+  const expectedUrl = new URL('https://us.yextevents.com/store_pagespixel');
   expectedUrl.searchParams.set('businessids', '0');
   expectedUrl.searchParams.set('product', 'sites');
   expectedUrl.searchParams.set('siteId', '0');
@@ -168,7 +168,7 @@ it('should track custom events', () => {
   }, httpRequesterService);
   reporter.track({eventType: eventName});
 
-  const expectedUrl = new URL('https://www.us.yextevents.com/store_pagespixel');
+  const expectedUrl = new URL('https://us.yextevents.com/store_pagespixel');
 
   expectedUrl.searchParams.set('businessids', '0');
   expectedUrl.searchParams.set('product', 'sites');
@@ -205,7 +205,7 @@ it('should use set the visitor', () => {
 
   reporter.pageView();
 
-  const expectedUrl = new URL('https://www.us.yextevents.com/store_pagespixel');
+  const expectedUrl = new URL('https://us.yextevents.com/store_pagespixel');
 
   expectedUrl.searchParams.set('businessids', '0');
   expectedUrl.searchParams.set('product', 'sites');
@@ -343,7 +343,7 @@ it('should set pageDomain when specified and valid', () => {
   }, httpRequesterService);
 
   reporter.pageView();
-  const expectedUrl = new URL('https://www.us.yextevents.com/store_pagespixel');
+  const expectedUrl = new URL('https://us.yextevents.com/store_pagespixel');
 
   expectedUrl.searchParams.set('businessids', '0');
   expectedUrl.searchParams.set('product', 'sites');
@@ -382,7 +382,7 @@ it('should log a warning and not include the pageDomain if it is missing a schem
   expect(console.warn).toBeCalledWith(errMsg1, errMsg2);
 
   reporter.pageView();
-  const expectedUrl = new URL('https://www.us.yextevents.com/store_pagespixel');
+  const expectedUrl = new URL('https://us.yextevents.com/store_pagespixel');
 
   expectedUrl.searchParams.set('businessids', '0');
   expectedUrl.searchParams.set('product', 'sites');

--- a/tests/infra/SearchAnalyticsReporter.ts
+++ b/tests/infra/SearchAnalyticsReporter.ts
@@ -12,7 +12,7 @@ it('The URL is constructed correctly', () => {
   const mockService = mockHttpRequesterService();
   const analyticsReporter = new SearchAnalyticsReporter(config, mockService);
   analyticsReporter.report({ type: 'SCROLL_TO_BOTTOM_OF_PAGE', queryId: '1' });
-  const expectedUrl = `https://www.us.yextevents.com/realtimeanalytics/data/answers/${config.businessId}`;
+  const expectedUrl = `https://us.yextevents.com/realtimeanalytics/data/answers/${config.businessId}`;
   expect(mockService.post).toHaveBeenLastCalledWith(expectedUrl, expect.anything());
 });
 
@@ -25,7 +25,7 @@ it('The URL is constructed correctly for EU', () => {
   const analyticsReporter = new SearchAnalyticsReporter(configWithEURegion, mockService);
   analyticsReporter.report({ type: 'SCROLL_TO_BOTTOM_OF_PAGE', queryId: '1' });
   const expectedUrl
-    = `https://www.eu.yextevents.com/realtimeanalytics/data/answers/${configWithEURegion.businessId}`;
+    = `https://eu.yextevents.com/realtimeanalytics/data/answers/${configWithEURegion.businessId}`;
   expect(mockService.post).toHaveBeenLastCalledWith(expectedUrl, expect.anything());
 });
 
@@ -38,7 +38,7 @@ it('The URL is constructed correctly for Sandbox', () => {
   const analyticsReporter = new SearchAnalyticsReporter(configWithSandboxEnv, mockService);
   analyticsReporter.report({ type: 'SCROLL_TO_BOTTOM_OF_PAGE', queryId: '1' });
   const expectedUrl
-    = `https://www.sbx.us.yextevents.com/realtimeanalytics/data/answers/${configWithSandboxEnv.businessId}`;
+    = `https://sbx.us.yextevents.com/realtimeanalytics/data/answers/${configWithSandboxEnv.businessId}`;
   expect(mockService.post).toHaveBeenLastCalledWith(expectedUrl, expect.anything());
 });
 


### PR DESCRIPTION
Pixels: Remove www prefix from yextevents URLs

Remove www from yextevent urls and tests.

J=FUS-5824
R=abenno, mtian
TEST=auto

The automatic checks in the github repo pass.
In addition, ran test-site in the analytics repo and fired off events.
All URL's with the yextevents domain did not have a www prefix.