### PR TITLE
Implement AnalyticsEventReporter constructor

### DIFF
--- a/src/AnalyticsEventReporter.ts
+++ b/src/AnalyticsEventReporter.ts
@@ -1,0 +1,36 @@
+import { AnalyticsEventService } from "./AnalyticsEventService"
+import { AnalyticsConfig } from "./AnalyticsConfig";
+import { EventPayload } from "./EventPayload";
+import { EventAPIResponse } from "./EventAPIResponse";
+
+/** Represents an reporter is responsible for reporting analytics events. */
+export class AnalyticsEventReporter implements AnalyticsEventService {
+
+    private config: AnalyticsConfig;
+    private payload?: EventPayload;
+
+    /**
+     * @param config - necessary analytics config: Must provide one and only
+     * one of API Key or Bearer Token.
+     * 
+     * @param payload - (optional) desired event values to report
+     */
+    constructor(config: AnalyticsConfig, payload?: EventPayload) {
+        const apiKeyIsSet = config.key !== undefined;
+        const bearerTokenIsSet = config.bearer !== undefined;
+        const configIsValid = (apiKeyIsSet || bearerTokenIsSet) && !(apiKeyIsSet && bearerTokenIsSet);
+        if (!configIsValid) {
+            throw new Error("Provide one and only one of API Key or Bearer Token.")
+        }
+        this.config = config;
+        this.payload = payload;
+    }
+
+    with(payload: EventPayload): AnalyticsEventService {
+        return new AnalyticsEventReporter(this.config);
+    }
+
+    report(payload: object): Promise<EventAPIResponse> | boolean {
+        return false;
+    }
+}

--- a/tests/AnalyticsEventReporter.test.ts
+++ b/tests/AnalyticsEventReporter.test.ts
@@ -1,0 +1,34 @@
+import { AnalyticsConfig } from "../src/AnalyticsConfig";
+import { AnalyticsEventReporter } from "../src/AnalyticsEventReporter";
+
+it("Invalid config with no authorization field", () => {
+    expect(() => new AnalyticsEventReporter({}))
+        .toThrowError("Provide one and only one of API Key or Bearer Token.")
+
+    const InvalidConfig: AnalyticsConfig = {
+        key: undefined
+    };
+    expect(() => new AnalyticsEventReporter(InvalidConfig))
+        .toThrowError("Provide one and only one of API Key or Bearer Token.")
+})
+
+it("Invalid config with both authorization field", () => {
+    const InvalidConfig: AnalyticsConfig = {
+        key: 'mock-api-key',
+        bearer: 'mock-bearer-token'
+    }
+    expect(() => new AnalyticsEventReporter(InvalidConfig))
+        .toThrowError("Provide one and only one of API Key or Bearer Token.")
+})
+
+it("Valid config will not throw error", () => {
+    const configwithAPI: AnalyticsConfig = {
+        key: 'mock-api-key'
+    }
+    expect(() => new AnalyticsEventReporter(configwithAPI)).not.toThrow();
+
+    const configwithBearer: AnalyticsConfig = {
+        bearer: 'mock-bearer-token'
+    }
+    expect(() => new AnalyticsEventReporter(configwithBearer)).not.toThrow();
+})


### PR DESCRIPTION
Set up the constructor for the AnalyticsEventReporter. Validate AnalyticsConfig only have one and only one of API Key or Bearer Token.

J=FUS-5871
TEST=auto