### PR TITLE
Update test site

### DIFF
--- a/src/AnalyticsEventReporter.ts
+++ b/src/AnalyticsEventReporter.ts
@@ -45,9 +45,9 @@ export class AnalyticsEventReporter implements AnalyticsEventService {
       }
 
       finalPayload.clientSdk
-        ? (finalPayload.clientSdk as Record<string, string>)[packageinfo.name] = packageinfo.version
+        ? (finalPayload.clientSdk as Record<string, string>)['ANALYTICS'] = packageinfo.version
         : finalPayload.clientSdk = {
-          [packageinfo.name]: packageinfo.version,
+          ['ANALYTICS']: packageinfo.version,
         };
 
       finalPayload.authorization = this.config.key

--- a/src/EventPayload.ts
+++ b/src/EventPayload.ts
@@ -74,16 +74,11 @@ export interface EventPayload {
    * Keys are case-insensitive.
    */
   customValues?: Record<string, number>;
-  /** The Yext entity to which the event corresponds.  */
-  entity?:
-    | {
-      /** The mutable, customer-settable entity ID for the entity associated with the event. */
-        entityId: string;
-      }
-    | {
-      /** The immutable entity ID set by the system. This is an internal ID. */
-        entityUid: number;
-      };
+  /** The Yext entity to which the event corresponds. If passed as a string, the value is
+   * the mutable, customer-settable entity ID for the entity associated with the event.
+   * If passed as a number, it is the immutable entity ID (UID) set by the system. This is an internal ID.
+   */
+  entity?: string | number
   /** The IP address for the event.*/
   ip?: {
     /** The IPv4 address associated with the event. */

--- a/src/post.ts
+++ b/src/post.ts
@@ -20,7 +20,11 @@ export function postWithBeacon(url: string, body: EventPayload): boolean {
  * @param body the EventPayload object
  */
 export function postWithFetch(url: string, body: EventPayload): Promise<Response> {
-  return fetch(url, {method: 'POST', body: JSON.stringify(body), keepalive: true});
+  return fetch(
+    url,
+    { method: 'POST',
+      headers: { 'Content-Type': 'application/json'},
+      body: JSON.stringify(body), keepalive: true});
 }
 
 /**

--- a/test-site/src/index.html
+++ b/test-site/src/index.html
@@ -1,11 +1,14 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8"/>
     <title>Analytics Testing</title>
-    <script src="bundle.js"></script>
+    <script src="bundle.js" defer></script>
   </head>
   <body>
     <button onclick="TestSite.fireChatEvent()">Fire Chat Event</button>
+    <button onclick="TestSite.fireCallToActionEvent()">Fire CTA event</button>
+    <button onclick="TestSite.fireSearchBarImpressionEvent()">Fire Search Bar Impression Event</button>
+    <button onclick="TestSite.fireEventWithSessionTracking()">Fire Event w/ Session Tracking</button>
   </body>
 </html>

--- a/test-site/src/index.ts
+++ b/test-site/src/index.ts
@@ -1,19 +1,110 @@
-import {analytics} from '@yext/analytics';
+import { analytics } from '@yext/analytics';
 
 
-const chat = analytics({
+const analyticsProvider = analytics({
   key: process.env.YEXT_API_KEY,
+  sessionTrackingEnabled: false
+}).with({
+  action: "CHAT_LINK_CLICK",
+  pageUrl: "http://www.yext-test-pageurl.com",
+  destinationUrl: "http://www.yext-test-destinationurl.com",
+  referrerUrl: "http://www.yext-test-referrerurl.com",
+  label: "test-label",
+  timestamp: new Date(),
+  bot: false,
+  browserAgent: {
+    browser: "test-browser",
+    browserVersion: "test-browser-version",
+    os: "test-os",
+    osVersion: "test-os-version",
+    device: "test-device",
+    deviceClass: "test-device-class",
+    userAgent: "test-user-agent",
+  },
+  clientSdk: {
+    "testsdk": "version",
+  },
+  internalUser: false,
+  chat: {
+    botId: "analytics-test-bot"
+  },
+    count: 1,
+  customTags: {
+    "testcustomtag": "testcustomtagvalue",
+  },
+  customValues: {
+    "testcustomvalue": 1,
+  },
+  entity: "testEntityId",
+  ip: {
+    address: "0.0.0.0",
+    algorithm: "HASH",
+  },
+  visitor: {
+    "test-id-method": "visitor-test-id",
+  },
+});
+
+
+const analyticsProvideWithSessionTracking = analytics({
+  key: process.env.YEXT_API_KEY,
+  sessionTrackingEnabled: true
+}).with({
+  action: "CHAT_LINK_CLICK",
+  pageUrl: "http://www.yext-test-pageurl.com",
+  destinationUrl: "http://www.yext-test-destinationurl.com",
+  referrerUrl: "http://www.yext-test-referrerurl.com",
+  label: "test-label",
+  timestamp: new Date(),
+  bot: false,
+  browserAgent: {
+    browser: "test-browser",
+    browserVersion: "test-browser-version",
+    os: "test-os",
+    osVersion: "test-os-version",
+    device: "test-device",
+    deviceClass: "test-device-class",
+    userAgent: "test-user-agent",
+  },
+  clientSdk: {
+    "sdk": "version",
+  },
+  internalUser: false,
+  chat: {
+    botId: "analytics-test-bot"
+  },
+  count: 1,
+  customTags: {
+    "testcustomtag": "testcustomtagvalue",
+  },
+  customValues: {
+    "testcustomvalue": 1,
+  },
+  entity: "testEntityId",
+  ip: {
+    address: "0.0.0.0",
+    algorithm: "HASH",
+  },
+  visitor: {
+    "test-id-method": "visitor-test-id",
+  },
 });
 
 export function fireChatEvent() {
-  chat.report({
-    action: "CHAT_LINK_CLICK",
-    referrerUrl: "http://www.yext-test-referrerurl.com",
-    visitor: {
-      "test-id-method": "visitor-test-id",
-    },
-    chat: {
-      botId: "analytics-test-bot"
-    }
-  })
+  analyticsProvider.report();
 }
+
+export function fireCallToActionEvent() {
+  analyticsProvider.report({action: "CALL_TO_ACTION"});
+}
+
+export function fireSearchBarImpressionEvent() {
+  analyticsProvider.report({action: "SEARCH_BAR_IMPRESSION"});
+}
+
+export function fireEventWithSessionTracking() {
+  analyticsProvideWithSessionTracking.report({
+    sessionId: "12345"
+  });
+}
+

--- a/tests/AnalyticsEventReporter.test.ts
+++ b/tests/AnalyticsEventReporter.test.ts
@@ -86,7 +86,7 @@ describe('Test report function', () => {
         action: 'APPLY',
         authorization: 'KEY validKey',
         clientSdk: {
-          '@yext/analytics': '1.0.0-beta.0'
+          ANALYTICS: '1.0.0-beta.0'
         },
         referrerUrl: 'https://yext.com',
         destinationUrl: 'https://google.com',
@@ -142,7 +142,7 @@ describe('Test report function', () => {
         action: 'ADD_TO_CART',
         authorization: 'Bearer bearerToken',
         clientSdk: {
-          '@yext/analytics': '1.0.0-beta.0'
+          ANALYTICS: '1.0.0-beta.0'
         },
         destinationUrl: 'https://google.com',
         count: 5,
@@ -206,7 +206,7 @@ describe('Test report function', () => {
           action: 'ADD_TO_CART',
           authorization: 'Bearer bearerToken',
           clientSdk: {
-            '@yext/analytics': '1.0.0-beta.0',
+            ANALYTICS: '1.0.0-beta.0',
             chat: '1.0.1.0',
           },
           destinationUrl: 'https://google.com',
@@ -245,7 +245,7 @@ describe('Test report function', () => {
         action: 'ADD_TO_CART',
         authorization: 'KEY validKey',
         clientSdk: {
-          '@yext/analytics': '1.0.0-beta.0'
+          ANALYTICS: '1.0.0-beta.0'
         },
         referrerUrl: 'https://yext.com',
         count: 5,
@@ -282,7 +282,7 @@ describe('Test report function', () => {
           action: 'ADD_TO_CART',
           authorization: 'KEY validKey',
           clientSdk: {
-            '@yext/analytics': '1.0.0-beta.0'
+            ANALYTICS: '1.0.0-beta.0'
           },
           referrerUrl: 'https://yext.com',
           count: 5,
@@ -336,7 +336,7 @@ describe('Test report function', () => {
         {
           authorization: 'KEY validKey',
           clientSdk: {
-            '@yext/analytics': '1.0.0-beta.0'
+            ANALYTICS: '1.0.0-beta.0'
           },
         });
     });
@@ -369,7 +369,7 @@ describe('Test report function', () => {
           action: 'ADD_TO_CART',
           authorization: 'KEY validKey',
           clientSdk: {
-            '@yext/analytics': '1.0.0-beta.0',
+            ANALYTICS: '1.0.0-beta.0',
           },
           referrerUrl: 'https://yext.com',
           count: 5,
@@ -398,7 +398,7 @@ describe('Test report function', () => {
           action: 'APPLY',
           authorization: 'KEY validKey',
           clientSdk: {
-            '@yext/analytics': '1.0.0-beta.0',
+            ANALYTICS: '1.0.0-beta.0',
             chat: '1.0.1.0',
           },
           destinationUrl: 'https://google.com',

--- a/tests/post.test.ts
+++ b/tests/post.test.ts
@@ -21,7 +21,10 @@ describe('Test post util function', () => {
 
   const url = 'https://dev.us.yextevents.com/accounts/me/events';
 
-  const optionsA = {method: 'POST', body: JSON.stringify(eventPayloadA), keepalive: true};
+  const optionsA = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json'},
+    body: JSON.stringify(eventPayloadA), keepalive: true};
 
   fetchMock.post(url, JSON.stringify(eventResponseA));
 


### PR DESCRIPTION
Update test site to use new version of SDK. In testing, this revealed some changes that needed to be made to the main package. These include updating the type of `entityId` in `EventPayload` to correctly match the Events Schema. This change also adds the Content-Type header to `postWithFetch` and updates associated tests. Lastly, this updates how we set clientSdk as using the package name is not supported since it includes special characters. 

To use the test-site:
- Run `npm i` in the main package
- Run `npm run build` in the main package
- Run `npm i` in test-site
- Run `npm run build` in test-site
- Run `npm run serve` in test-site