### PR TITLE
Fix setupRequestUrl

### DIFF
--- a/src/AnalyticsEventReporter.ts
+++ b/src/AnalyticsEventReporter.ts
@@ -73,7 +73,7 @@ export class AnalyticsEventReporter implements AnalyticsEventService {
         const body: EventAPIResponse = await res?.json();
         let errorMessage = `Events API responded with ${res?.status}: ${res?.statusText}`;
         body?.errors?.forEach(e => errorMessage += `\nError: ${e}.`);
-        throw Error(errorMessage);
+        throw new Error(errorMessage);
       }
       const resJson = await res?.json();
       return resJson;

--- a/src/setupRequestUrl.ts
+++ b/src/setupRequestUrl.ts
@@ -1,8 +1,11 @@
 import { Environment, EnvironmentEnum } from './Environment';
-import { Region } from './Region';
+import { Region, RegionEnum } from './Region';
 
 const urlBase = 'yextevents.com/accounts/me/events';
 
 export function setupRequestUrl(env?: Environment, region?: Region): string {
+  if (env === EnvironmentEnum.Sandbox && region === RegionEnum.EU) {
+    throw new Error('Sandbox environment is not available in the EU region.');
+  }
   return 'https://' + (env === EnvironmentEnum.Sandbox ? 'sbx.' : '') + (region ?? 'us') + '.' + urlBase;
 }

--- a/tests/setupRequestUrl.test.ts
+++ b/tests/setupRequestUrl.test.ts
@@ -24,11 +24,14 @@ describe('setUpRequestUrl Test', () => {
     expect(resultUrl).toEqual(expectedUrl);
   });
 
-  it('should set url correctly for env: sbx, region: eu', () => {
-    const resultUrl = setupRequestUrl(EnvironmentEnum.Sandbox, RegionEnum.EU);
-    const expectedUrl = 'https://sbx.eu.yextevents.com/accounts/me/events';
-
-    expect(resultUrl).toEqual(expectedUrl);
+  it('should throw error for env: sbx, region: eu', () => {
+    try {
+      setupRequestUrl(EnvironmentEnum.Sandbox, RegionEnum.EU);
+      // Fail test if above expression doesn't throw anything.
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.message).toBe('Sandbox environment is not available in the EU region.');
+    }
   });
 
   it('should set url correctly with no arguments passed in', () => {

--- a/tests/setupRequestUrl.test.ts
+++ b/tests/setupRequestUrl.test.ts
@@ -3,30 +3,61 @@ import { RegionEnum } from '../src/Region';
 import { setupRequestUrl } from '../src/setupRequestUrl';
 
 describe('setUpRequestUrl Test', () => {
-  it('should set url correctly for env: prod, region: us', () => {
+  it('should set url correctly for env: prod, region: us using their Enums', () => {
     const resultUrl = setupRequestUrl(EnvironmentEnum.Production, RegionEnum.US);
     const expectedUrl = 'https://us.yextevents.com/accounts/me/events';
 
     expect(resultUrl).toEqual(expectedUrl);
   });
 
-  it('should set url correctly for env: prod, region: eu', () => {
+  it('should set url correctly for env: prod, region: us using their string literals', () => {
+    const resultUrl = setupRequestUrl('PRODUCTION', 'us');
+    const expectedUrl = 'https://us.yextevents.com/accounts/me/events';
+
+    expect(resultUrl).toEqual(expectedUrl);
+  });
+
+  it('should set url correctly for env: prod, region: eu using their Enums', () => {
     const resultUrl = setupRequestUrl(EnvironmentEnum.Production, RegionEnum.EU);
     const expectedUrl = 'https://eu.yextevents.com/accounts/me/events';
 
     expect(resultUrl).toEqual(expectedUrl);
   });
 
-  it('should set url correctly for env: sbx, region: us', () => {
+  it('should set url correctly for env: prod, region: eu using their string literals', () => {
+    const resultUrl = setupRequestUrl('PRODUCTION', 'eu');
+    const expectedUrl = 'https://eu.yextevents.com/accounts/me/events';
+
+    expect(resultUrl).toEqual(expectedUrl);
+  });
+
+  it('should set url correctly for env: sbx, region: us using their Enums', () => {
     const resultUrl = setupRequestUrl(EnvironmentEnum.Sandbox, RegionEnum.US);
     const expectedUrl = 'https://sbx.us.yextevents.com/accounts/me/events';
 
     expect(resultUrl).toEqual(expectedUrl);
   });
 
-  it('should throw error for env: sbx, region: eu', () => {
+  it('should set url correctly for env: sbx, region: us using their string literals', () => {
+    const resultUrl = setupRequestUrl('SANDBOX', 'us');
+    const expectedUrl = 'https://sbx.us.yextevents.com/accounts/me/events';
+
+    expect(resultUrl).toEqual(expectedUrl);
+  });
+
+  it('should throw error for env: sbx, region: eu using their Enums', () => {
     try {
       setupRequestUrl(EnvironmentEnum.Sandbox, RegionEnum.EU);
+      // Fail test if above expression doesn't throw anything.
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.message).toBe('Sandbox environment is not available in the EU region.');
+    }
+  });
+
+  it('should throw error for env: sbx, region: eu using their string literals', () => {
+    try {
+      setupRequestUrl('SANDBOX', 'eu');
       // Fail test if above expression doesn't throw anything.
       expect(true).toBe(false);
     } catch (e) {
@@ -41,15 +72,29 @@ describe('setUpRequestUrl Test', () => {
     expect(resultUrl).toEqual(expectedUrl);
   });
 
-  it('should set url correctly with no env argument passed in', () => {
+  it('should set url correctly with no env argument passed in using its Enum', () => {
     const resultUrl = setupRequestUrl(undefined, RegionEnum.EU);
     const expectedUrl = 'https://eu.yextevents.com/accounts/me/events';
 
     expect(resultUrl).toEqual(expectedUrl);
   });
 
-  it('should set url correctly with no region argument passed in', () => {
+  it('should set url correctly with no env argument passed in using their string literals', () => {
+    const resultUrl = setupRequestUrl(undefined, 'eu');
+    const expectedUrl = 'https://eu.yextevents.com/accounts/me/events';
+
+    expect(resultUrl).toEqual(expectedUrl);
+  });
+
+  it('should set url correctly with no region argument passed in using its Enum', () => {
     const resultUrl = setupRequestUrl(EnvironmentEnum.Sandbox, undefined);
+    const expectedUrl = 'https://sbx.us.yextevents.com/accounts/me/events';
+
+    expect(resultUrl).toEqual(expectedUrl);
+  });
+
+  it('should set url correctly with no region argument passed in using their string literals', () => {
+    const resultUrl = setupRequestUrl('SANDBOX', undefined);
     const expectedUrl = 'https://sbx.us.yextevents.com/accounts/me/events';
 
     expect(resultUrl).toEqual(expectedUrl);


### PR DESCRIPTION
Fix setupRequestUrl to throw error when env: sandbox and region: eu passed in as sandbox is not supported in the EU region. Also update AnalyticsEventReporter to use the `new` keyword when throwing an error, as that is the correct syntax. 

R=mtian, abenno
TEST=unit

Updated unit test for error case. Ran `npm run test` and all pass. 