### PR TITLE
EventsSDK: Update v0 to use keepalive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/analytics",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/analytics",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "An analytics library for Yext",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",

--- a/src/infra/HttpRequester.ts
+++ b/src/infra/HttpRequester.ts
@@ -32,6 +32,7 @@ export class HttpRequester implements HttpRequesterService {
     const fetchInit: RequestInit = {
       method: 'GET',
       mode: 'no-cors',
+      keepalive: true,
     };
 
     if (typeof (window) !== 'undefined' && window.fetch) {


### PR DESCRIPTION
Users with v0.6.4 were experiencing requests erroring when users navigate away from the page. This adds the use of the keepalive flag which should prevent this error in browsers that support it.

J=FUS-5933
R=mtian, abenno
TEST=manual

Ran test site