### PR TITLE
EventsSDK: Add new CDN Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build Chat assets
+
+on:
+  workflow_call:
+    inputs:
+      build_script:
+        required: false
+        default: build
+        type: string
+      region:
+        required: false
+        default: US
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm"
+      - run: npm ci
+      - run: VITE_REGION=${{ inputs.region }} npm run ${{ inputs.build_script }}
+      - name: Create build-output-${{ inputs.region }} artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-output-${{ inputs.region }}
+          path: dist/ 

--- a/.github/workflows/build_and_deploy_hold.yml
+++ b/.github/workflows/build_and_deploy_hold.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch: # allow manual run
 
 jobs:
   call_build_US:

--- a/.github/workflows/build_and_deploy_hold.yml
+++ b/.github/workflows/build_and_deploy_hold.yml
@@ -1,0 +1,71 @@
+name: Build and deploy with a hold state
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  call_build_US:
+    uses: ./.github/workflows/build.yml
+    with:
+      region: US
+
+  call_build_EU:
+    uses: ./.github/workflows/build.yml
+    with:
+      region: EU
+
+  call_extract_versions:
+    uses: ./.github/workflows/extract_versions.yml
+
+  call_should_deploy_major_version:
+    uses: ./.github/workflows/should_deploy_major_version.yml
+
+  call_deploy_full_version:
+    needs:
+      - call_build_US
+      - call_build_EU
+      - call_extract_versions
+    uses: ./.github/workflows/deploy_hold.yml
+    with:
+      directory: ${{ needs.call_extract_versions.outputs.full_version }}
+      cache-control: "max-age=31536000"
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+
+  call_deploy_major_version:
+    needs:
+      - call_build_US
+      - call_build_EU
+      - call_extract_versions
+      - call_should_deploy_major_version
+    if: ${{ needs.call_should_deploy_major_version.outputs.should_deploy_major_version }}
+    uses: ./.github/workflows/deploy_hold.yml
+    with:
+      directory: ${{ needs.call_extract_versions.outputs.major_version }}
+      cache-control: "max-age=43200"
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+
+  call_deploy_minor_version:
+    needs:
+      - call_build_US
+      - call_build_EU
+      - call_extract_versions
+    uses: ./.github/workflows/deploy_hold.yml
+    with:
+      directory: ${{ needs.call_extract_versions.outputs.minor_version }}
+      cache-control: "max-age=43200"
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+
+concurrency:
+  group: ci-build-and-deploy-hold-${{ github.ref }}-1
+  cancel-in-progress: true

--- a/.github/workflows/extract_versions.yaml
+++ b/.github/workflows/extract_versions.yaml
@@ -1,0 +1,40 @@
+name: Extract package versions
+
+# Extract package version based on GITHUB_REF_NAME, which is the
+# name of the branch or tag that triggered the workflow run
+
+on:
+  workflow_call:
+    inputs:
+      ignore_prefix:
+        required: false
+        default: ""
+        type: string
+    outputs:
+      major_version:
+        value: ${{ jobs.extract_versions.outputs.major_version }}
+      minor_version:
+        value: ${{ jobs.extract_versions.outputs.minor_version }}
+      full_version:
+        value: ${{ jobs.extract_versions.outputs.full_version }}
+
+jobs:
+  extract_versions:
+    runs-on: ubuntu-latest
+    outputs:
+      minor_version: ${{ steps.vars.outputs.minor_version }}
+      major_version: ${{ steps.vars.outputs.major_version }}
+      full_version: ${{ steps.vars.outputs.full_version }}
+    steps:
+      - name: extract major and minor version substrings
+        id: vars
+        run: |
+          MAJOR_VERSION="$(echo "${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}" | cut -d '.' -f 1)"
+          echo "Major version: $MAJOR_VERSION"
+          echo major_version=${MAJOR_VERSION} >> $GITHUB_OUTPUT
+          MINOR_VERSION="$(echo "${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}" | cut -d '.' -f 1,2)"  
+          echo "Minor version: $MINOR_VERSION"
+          echo minor_version=${MINOR_VERSION} >> $GITHUB_OUTPUT
+          FULL_VERSION="${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}"
+          echo "Full version: $FULL_VERSION"
+          echo full_version=${FULL_VERSION} >> $GITHUB_OUTPUT

--- a/.github/workflows/should_deploy_major_version.yml
+++ b/.github/workflows/should_deploy_major_version.yml
@@ -1,0 +1,39 @@
+name: Should deploy major version
+
+# This is useful for cases of patching older versions. Patching version 1.2.0 when
+# there an existing a version 1.3.0 means the major version shouldn't get updated.
+
+on:
+  workflow_call:
+    inputs:
+      ignore_prefix:
+        required: false
+        default: ""
+        type: string
+    outputs:
+      should_deploy_major_version:
+        value: ${{ jobs.should_deploy_major_version.outputs.should_deploy_major_version }}
+
+jobs:
+  should_deploy_major_version:
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy_major_version: ${{ steps.vars.outputs.should_deploy_major_version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: allow for major version deployment if the next minor version from current tag does not exist
+        id: vars
+        run: |
+          MINOR_VERSION=$(echo "${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}" | cut -d '.' -f 2) 
+          MAJOR_VERSION=$(echo "${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}" | cut -d '.' -f 1)
+          NEXT_MINOR_VERSION=$(( $MINOR_VERSION + 1 ))
+          TAGS_FOR_NEXT_MINOR=$(git tag --list "${{ inputs.ignore_prefix }}$MAJOR_VERSION.$NEXT_MINOR_VERSION.*")
+          if [ -z "$TAGS_FOR_NEXT_MINOR" ]
+          then
+            echo 'Major version should be deployed.'
+            echo should_deploy_major_version=true >> $GITHUB_OUTPUT
+          else
+            echo 'Major version should not be deployed.'
+          fi


### PR DESCRIPTION
Add actions required for deploying package to CDN (aws in US and gcp in eu)

Here's how this works:

- build_and_deploy_hold.yml is called when a new version tag is added. (can also be manually triggered)
- This calls build.yml which uses vite to generate a build-output-region file
- calls extract_versions and should_deploy_major_version to determine the version and what needs to be deployed.
- calls deploy_hold which deploys to aws/gcp using secret keys.
- Unfortunately I do think this needs to be merged into main in order to confirm a deployment works. Then in order to trigger it, we'd need to add a new release tag.