### PR TITLE
Fix Husky Setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "build": "rm -rf lib/** && tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json && npm run format-check && npm run api-extractor && npm run generate-docs && npm run generate-notices && vite build",
+    "prepare": "husky install",
     "format-check": "prettier --check . && eslint .",
     "format-fix": "prettier --write . && eslint . --fix",
     "api-extractor": "api-extractor run --local --verbose",


### PR DESCRIPTION
When running `npm i`, some of the script, including `prepare`, under package.json will also run. 
https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts
Without "prepare": "husky install", husky will not set up correctly.

TEST=manual

Run npm i and commit changes, see expected Prettier and ESLint output.