### PR TITLE
EventsSDK: Playwright Improvements

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         node-version: 18
     - name: Install dependencies
-      run: npm ci && npm i --prefix ./test-site
+      run: npm ci
     - name: build package
       run: npm run build
     - name: Run Playwright tests

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,9 +45,10 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run build && npm run serve',
+    command: 'npm i && npm run build && npm run serve',
     cwd: './test-site',
     port: 3000,
-    reuseExistingServer: !process.env.CI
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe'
   }
 });

--- a/test-cdn/index.html
+++ b/test-cdn/index.html
@@ -6,13 +6,14 @@
   </head>
   <body>
     <p>Analytics Script Tag Integration Test Site</p>
-    <!-- <script src="https://storage.googleapis.com/assets-eu.sitescdn.net/chat/v0/chat.umd.js"></script> -->
-    <!-- <script src="https://assets.sitescdn.net/chat/v0/chat.umd.js"></script> -->
-    <script src="../dist/analytics.umd.js"></script>
+    <!-- LOCAL DEPLOYABLE <script src="../dist/analytics.umd.js"></script>-->
+    <!-- GCP SCRIPT TAG FOR EU <script src="https://storage.googleapis.com/assets-eu.sitescdn.net/analytics/v1.0.0-beta.1/analytics.umd.js"></script> -->
+    <!-- AWS SCRIPT TAG FOR US <script src="https://assets.sitescdn.net/analytics/v1.0.0-beta.1/analytics.umd.js"></script> -->
     <script>
       const analyticsProvider = window.AnalyticsSDK.analytics({
-        key: '%YEXT_API_KEY%',
-        sessionTrackingEnabled: false
+        key: '<INSERT YEXT API KEY HERE>',
+        sessionTrackingEnabled: false,
+        region: 'eu'
       }).with({
         action: 'CHAT_LINK_CLICK',
         pageUrl: 'http://www.yext-test-pageurl.com',

--- a/test-e2e/playwright.test.ts
+++ b/test-e2e/playwright.test.ts
@@ -1,4 +1,8 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+test.beforeAll(async () => {
+  expect(process.env.YEXT_API_KEY).toBeDefined();
+});
 
 test('test Fire Chat Event on Chromium, Firefox, and Webkit', async ({
   page


### PR DESCRIPTION
* Add a `beforeAll` check in tests than ensures an API Key is set as the rest of the tests depend on this
* Move the call to `npm i` on the test site to the webServer playwright config, instead of it being called in the GitHub action. 
* Update the CDN test site to use the correct links