### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ In many cases, you might need to repeatedly specify the same properties, such as
 You can add a `.with()` method to the root analytics service you initialized, which returns a new analytics object with the specified JSON merged on top of the existing defaults.
 
 ```ts
-import { Analytics } from '@yext/analytics';
+import { analytics } from '@yext/analytics';
 
 // Root analytics service with no defaults.
-const rootAnalytics = new Analytics({ key: 'MY_API_KEY' });
+const rootAnalytics = analytics({ key: 'MY_API_KEY' });
 
 // Pages analytics service with Pages defaults.
 const pageAnalytics = rootAnalytics.with({ pages: { siteId: 123 } });


### PR DESCRIPTION
Update README.md to `import { analytics } from "@yext/analytics"` instead of `import { Analytics }...`, and remove usages of `new`.

J=FUS-6200
TEST=manual

Since the test site does `import { analytics } from "@yext/analytics"`, and calls the analytics function without using the `new` keyword, I ran the test site and confirmed that clicking the buttons successfully fired analytics events.