### PR TITLE
EventsSDK: Stop committing unstaged files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run format-fix
-git add .


### PR DESCRIPTION
For some reason when we set up the commit hook for the SDK repository we set it the pre-commit hook to stage all files. This can be annoying if you modified a file not intended to be committed, like a test-site file. 

This change removes the relevant line from the pre-commit hook. 

R=mtian, pcammarata, abenno
TEST=manual

Confirmed that making a change to a file in the repo without staging it, then running git commit, does not result in that file committed. 