### PR TITLE
AnalyticsSDK: Add new optional scope Event Payload field for pages

### DIFF
--- a/docs/analytics.eventpayload.md
+++ b/docs/analytics.eventpayload.md
@@ -32,7 +32,7 @@ export interface EventPayload
 |  [label?](./analytics.eventpayload.label.md) |  | string | _(Optional)_ A label assigned to the event, e.g. a CTA label. |
 |  [locale?](./analytics.eventpayload.locale.md) |  | string | _(Optional)_ The locale of the user who generated the event. |
 |  [location?](./analytics.eventpayload.location.md) |  | Coordinates \| string | _(Optional)_ The location information of the visitor for the event. Either a Coordinates object with both latitude and longitude or a string with the country of the visitor for the event, as a ISO 3166-1 alpha-2 country code. |
-|  [pages?](./analytics.eventpayload.pages.md) |  | { siteUid?: number; template?: string; } | _(Optional)_ Fields specific to reporting Yext Pages Analytics Events |
+|  [pages?](./analytics.eventpayload.pages.md) |  | { scope?: string; siteUid?: number; template?: string; } | _(Optional)_ Fields specific to reporting Yext Pages Analytics Events |
 |  [pageUrl?](./analytics.eventpayload.pageurl.md) |  | string | _(Optional)_ The URL of the page where the event occurred |
 |  [referrerUrl?](./analytics.eventpayload.referrerurl.md) |  | string | _(Optional)_ The URL of the page which the visitor came from prior to the event. |
 |  [search?](./analytics.eventpayload.search.md) |  | { searchId?: string; queryId?: string; verticalKey?: string; isDirectAnswer?: boolean; versionLabel?: [VersionLabel](./analytics.versionlabel.md)<!-- -->; versionNumber?: number; experienceKey: string; } | _(Optional)_ Fields specific to reporting Yext Search Analytics Events |

--- a/docs/analytics.eventpayload.pages.md
+++ b/docs/analytics.eventpayload.pages.md
@@ -10,6 +10,7 @@ Fields specific to reporting Yext Pages Analytics Events
 
 ```typescript
 pages?: {
+        scope?: string;
         siteUid?: number;
         template?: string;
     };

--- a/etc/analytics.api.md
+++ b/etc/analytics.api.md
@@ -65,6 +65,7 @@ export interface EventPayload {
     // Warning: (ae-forgotten-export) The symbol "Coordinates" needs to be exported by the entry point index.d.ts
     location?: Coordinates | string;
     pages?: {
+        scope?: string;
         siteUid?: number;
         template?: string;
     };

--- a/src/EventPayload.ts
+++ b/src/EventPayload.ts
@@ -111,6 +111,8 @@ export interface EventPayload {
   sessionId?: string | null;
   /** Fields specific to reporting Yext Pages Analytics Events */
   pages?: {
+    /** The scope of an action. Applies to Pages events. */
+    scope?: string;
     /* The UID of the site an event was tied to. */
     siteUid?: number;
     /* The ID of the template from which a site was generated. */


### PR DESCRIPTION
This CR creates a new optional string field that denotes the scope of pages actions in event payloads.

J=FUS-6253
TEST=none