### PR TITLE
EventsSDK: make entityId optional for search's CtaEvent

### DIFF
--- a/docs/analytics.ctaevent.entityid.md
+++ b/docs/analytics.ctaevent.entityid.md
@@ -9,5 +9,5 @@ The entity ID for the entity.
 <b>Signature:</b>
 
 ```typescript
-entityId: string;
+entityId?: string;
 ```

--- a/docs/analytics.ctaevent.md
+++ b/docs/analytics.ctaevent.md
@@ -18,7 +18,7 @@ export interface CtaEvent
 |  --- | --- | --- |
 |  [ctaLabel?](./analytics.ctaevent.ctalabel.md) | 'video\_played' \| string | <i>(Optional)</i> The label for this CTA event. |
 |  [directAnswer?](./analytics.ctaevent.directanswer.md) | boolean | <i>(Optional)</i> Whether or not the event was fired on a direct answer card. |
-|  [entityId](./analytics.ctaevent.entityid.md) | string | The entity ID for the entity. |
+|  [entityId?](./analytics.ctaevent.entityid.md) | string | <i>(Optional)</i> The entity ID for the entity. |
 |  [fieldName?](./analytics.ctaevent.fieldname.md) | string | <i>(Optional)</i> The name of the Rich Text field used. |
 |  [generativeDirectAnswer?](./analytics.ctaevent.generativedirectanswer.md) | boolean | <i>(Optional)</i> Whether or not the event was fired on a generative direct answer card. |
 |  [queryId](./analytics.ctaevent.queryid.md) | string | The ID of the most recent query. |

--- a/etc/analytics.api.md
+++ b/etc/analytics.api.md
@@ -107,7 +107,7 @@ export const CtaClick: PagesAnalyticsEvent;
 export interface CtaEvent {
     ctaLabel?: 'video_played' | string;
     directAnswer?: boolean;
-    entityId: string;
+    entityId?: string;
     fieldName?: string;
     generativeDirectAnswer?: boolean;
     queryId: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/analytics",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/analytics",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/analytics",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "An analytics library for Yext",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",

--- a/src/models/search/events/CtaEvent.ts
+++ b/src/models/search/events/CtaEvent.ts
@@ -31,7 +31,7 @@ export interface CtaEvent {
    */
   verticalKey: string,
   /** The entity ID for the entity. */
-  entityId: string,
+  entityId?: string,
   /** Whether it was on universal or vertical search. */
   searcher: Searcher,
   /** The ID of the most recent query. */


### PR DESCRIPTION
In search, a click event fired on a Generative Direct Answer card might not have an entity associated with it. Specifically, if the direct answer text has a link, we do not know which entity that link comes from, but we want to be able to report the link click event as a CTA event.